### PR TITLE
Fix wget command

### DIFF
--- a/bpcs_uploader.php
+++ b/bpcs_uploader.php
@@ -74,7 +74,7 @@ case 'download':
     die();
   }
   $path='/apps/'.urlencode(file_get_contents(CONFIG_DIR.'/appname').'/'.$argv[3]);
-  $cmd = 'wget --no-check-certificate -O "'.$argv[2].'" "https://d.pcs.baidu.com/rest/2.0/pcs/file?method=download&access_token='.$access_token.'&path='.$path.'"';
+  $cmd = 'wget -c --no-check-certificate -O "'.$argv[2].'" "https://d.pcs.baidu.com/rest/2.0/pcs/file?method=download&access_token='.$access_token.'&path='.$path.'"';
   cmd($cmd);
   break;
 case 'delete':


### PR DESCRIPTION
WGet命令做了如下改动，虽然不是大问题，但我觉得改了比较好一些：
1 下载后的发现文件名末端带空格（环境：debian php5.2），所以删除一个空格
2 加上-c参数，以支持断点续传下载功能
